### PR TITLE
Fix barcode definition inconsistency in ProductVariant

### DIFF
--- a/models/entities/product/product.md
+++ b/models/entities/product/product.md
@@ -88,7 +88,7 @@ The ProductVariant entity represents individual sellable items with specific att
 | `cost`              | Cost of goods for margin calculations using [money](../utilities/money.md) utility object | COULD    |
 | `weight`            | Physical weight for shipping calculations               | SHOULD   |
 | `dimensions`        | Physical dimensions (length, width, height)             | COULD    |
-| `barcodes`          | Array of barcode objects (type, value; e.g., UPC, GTIN) | COULD    |
+| `barcodes`          | Object of barcode identifiers (e.g., UPC, GTIN, MPN)     | COULD    |
 | `inventory`         | Inventory levels and tracking                           | SHOULD   |
 | `tax_category`      | Tax classification override (if different from product) | COULD    |
 | `shipping_required` | Whether physical shipping is needed                     | SHOULD   |
@@ -656,10 +656,10 @@ A simple product with only one variant (following the pattern that every product
     "value": 200,
     "unit": "g"
     },
-    "barcodes": [
-      { "upc", "1234567890123" },
-      { "gtin", "9876543210987" }
-    ],
+    "barcodes": {
+      "upc": "1234567890123",
+      "gtin": "9876543210987"
+    },
     "shipping_required": true
   }
   ],


### PR DESCRIPTION
Align field description, YAML schema, and sample object to consistently use object structure for barcodes field. This matches the original PR #46 intent while providing the simplest and most practical implementation.

Changes:
- Update field description from "Array of barcode objects" to "Object of barcode identifiers"
- Fix sample object from malformed array syntax to proper object syntax
- Schema was already correct as object type

The object structure supports all real-world use cases including multiple GTIN formats (gtin-8, gtin-12, gtin-13, gtin-14) and different barcode standards (upc, ean, isbn, mpn) using distinct keys.